### PR TITLE
feat: Add support to specify the full url

### DIFF
--- a/lib/plug/redoc_ui.ex
+++ b/lib/plug/redoc_ui.ex
@@ -46,7 +46,7 @@ defmodule Redoc.Plug.RedocUI do
          <%= k %>="<%= v %>"
         <% end %>
       ></redoc>
-      <script src="https://cdn.jsdelivr.net/npm/redoc@<%= Plug.HTML.html_escape(redoc_version) %>/bundles/redoc.standalone.js"></script>
+      <script src="<%= redoc_url %>"></script>
     </body>
   </html>
   """
@@ -99,7 +99,12 @@ defmodule Redoc.Plug.RedocUI do
     redoc_version = Keyword.get(opts, :redoc_version, "latest")
     title = Keyword.get(opts, :title, "ReDoc")
 
-    [redoc_opts: redoc_opts, redoc_version: redoc_version, title: title]
+    default_url =
+      "https://cdn.jsdelivr.net/npm/redoc@#{Plug.HTML.html_escape(redoc_version)}/bundles/redoc.standalone.js"
+
+    redoc_url = Keyword.get(opts, :redoc_url, default_url)
+
+    [redoc_opts: redoc_opts, redoc_url: redoc_url, title: title]
   end
 
   @impl true


### PR DESCRIPTION
This PR adds the option to set a totally different url for the redoc standalone bundle.

Basically this is to allow use cases like mine where I use a forked version of redoc and compile the bundle myself, I then place the bundle inside Phoenix itself and load it like this in the plug:

```elixir
      forward "/redoc", Redoc.Plug.RedocUI,
        redoc_url: "/redoc/redoc.standalone.js"
```